### PR TITLE
merge: resolve background color conflict between light and dark themes

### DIFF
--- a/style.css
+++ b/style.css
@@ -16,7 +16,7 @@
 }
 body {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  background-color: #f9f9f9;
+  background-color: #1a1a1a;
   color: #333;
   line-height: 1.6;
 }

--- a/style.css
+++ b/style.css
@@ -16,7 +16,7 @@
 }
 body {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  background-color: #f9f9f9;
+  background-color:#f9f9f9;
   color: #333;
   line-height: 1.6;
 }


### PR DESCRIPTION
This pull request resolves a merge conflict that occurred between the feature-bg-light and feature-bg-dark branches, specifically in the child.css file.

What was the conflict about?

Both branches had different background color styles for the body element:

feature-bg-light: #f9f9f9

feature-bg-dark: #1a1a1a


How it was resolved:

After reviewing both changes, a new background color was chosen to resolve the conflict and maintain design consistency.

SCM Concepts Demonstrated:

Feature branching (feature-bg-light)

Merge conflict simulation

Manual conflict resolution in CSS

Commit after conflict fix

Push to remote after resolution